### PR TITLE
Add item `service` to API-catalog

### DIFF
--- a/catalogs/api.json
+++ b/catalogs/api.json
@@ -10,6 +10,7 @@
     "name": "Database store",
     "description": "An API for storing meta-information of databases",
     "endpoint": "/database_store",
+    "service": "api-database-store",
     "schema": "git@github.com:dataware-tools/protocols.git/schemas/apis/api-database-store/schema.v1.yaml"
   },
   "recordStore": {
@@ -17,6 +18,7 @@
     "name": "Record store",
     "description": "An API for fetching record metadata",
     "endpoint": "/record_store",
+    "service": "api-record-store",
     "schema": "git@github.com:dataware-tools/protocols.git/schemas/apis/api-record-store/schema.v1.yaml"
   },
   "dataBrowserConfigStore": {
@@ -24,6 +26,7 @@
     "name": "Data-browser config store",
     "description": "An API for storoing configs of data-browser",
     "endpoint": "/data_browser_config_store",
+    "service": "api-data-browser-config-store",
     "schema": "git@github.com:dataware-tools/protocols.git/schemas/apis/api-data-browser-config-store/schema.v1.yaml"
   },
   "jobStore": {
@@ -31,6 +34,7 @@
     "name": "Job store",
     "description": "An API for jobs",
     "endpoint": "/job_store",
+    "service": "api-job-store",
     "schema": "git@github.com:dataware-tools/protocols.git/schemas/apis/api-job-store/schema.v1.yaml"
   }
 }


### PR DESCRIPTION
## What?
API カタログに `service` という項目を追加

## Why?
クラスタ内でのバックエンド間の通信での宛先をカタログから引いてこれるようにするため
