### PR TITLE
Fix API name from permission-store to permission-manager

### DIFF
--- a/schemas/apis/api-permission-manager/schema.v1.yaml
+++ b/schemas/apis/api-permission-manager/schema.v1.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.2
 info:
-  title: permission store
+  title: permission manager
   version: '1.0'
   description: Permision manage APIs
   contact:


### PR DESCRIPTION
## What?
api-permission-manager のOpenAPI仕様書のAPI名を `permission store` から `permission manager` に修正

## Why?
混乱を避けるため