### PR TITLE
remove duplicated parameters

### DIFF
--- a/schemas/apis/api-meta-store/schema.v1.yaml
+++ b/schemas/apis/api-meta-store/schema.v1.yaml
@@ -13,16 +13,16 @@ servers:
   - url: 'http://localhost:8080'
 paths:
   '/records/{record_id}':
+    parameters:
+      - schema:
+          type: string
+        name: record_id
+        in: path
+        required: true
     get:
       operationId: getRecord
       description: Return the detail of the record.
       parameters:
-        - name: record_id
-          in: path
-          required: true
-          description: record_id
-          schema:
-            type: string
         - schema:
             type: string
           in: query
@@ -243,16 +243,15 @@ paths:
                         - center
                         - timestamps
   '/databases/{database_id}':
+    parameters:
+      - schema:
+          type: string
+        name: database_id
+        in: path
+        required: true
     get:
       operationId: getDatabase
       description: Return information of the database.
-      parameters:
-        - name: database_id
-          in: path
-          required: true
-          description: ''
-          schema:
-            type: string
       summary: Get database information
       responses:
         '200':


### PR DESCRIPTION
## What?
- remove duplicated parameter

## Why?
- below error occur in building app-common
```
(rpt2 plugin) Error: /home/kz86/ghq/github.com/dataware-tools/app-common/src/openapi/metaStore/client/services/RecordService.ts(23,9): semantic error TS2300: Duplicate identifier 'recordId'.
Error: /home/kz86/ghq/github.com/dataware-tools/app-common/src/openapi/metaStore/client/services/RecordService.ts(23,9): semantic error TS2300: Duplicate identifier 'recordId'.
    at error (/home/kz86/ghq/github.com/dataware-tools/app-common/node_modules/rollup/dist/shared/rollup.js:5305:30)
    at throwPluginError (/home/kz86/ghq/github.com/dataware-tools/app-common/node_modules/rollup/dist/shared/rollup.js:18040:12)
    at Object.error (/home/kz86/ghq/github.com/dataware-tools/app-common/node_modules/rollup/dist/shared/rollup.js:18666:20)
    at Object.error (/home/kz86/ghq/github.com/dataware-tools/app-common/node_modules/rollup/dist/shared/rollup.js:18209:38)
    at RollupContext.error (/home/kz86/ghq/github.com/dataware-tools/app-common/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:17237:30)
    at /home/kz86/ghq/github.com/dataware-tools/app-common/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:25033:23
    at arrayEach (/home/kz86/ghq/github.com/dataware-tools/app-common/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:545:11)
    at Function.forEach (/home/kz86/ghq/github.com/dataware-tools/app-common/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:9397:14)
    at printDiagnostics (/home/kz86/ghq/github.com/dataware-tools/app-common/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:25006:12)
    at Object.transform (/home/kz86/ghq/github.com/dataware-tools/app-common/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:29275:17)
```