### PR TITLE
Fix operation id of meta-store to camel case

### DIFF
--- a/schemas/apis/api-meta-store/schema.v1.yaml
+++ b/schemas/apis/api-meta-store/schema.v1.yaml
@@ -64,7 +64,7 @@ paths:
         - record
     delete:
       summary: Delete record information
-      operationId: deleterecord
+      operationId: deleteRecord
       responses:
         '200':
           description: OK
@@ -80,7 +80,7 @@ paths:
           required: true
     patch:
       summary: Update record information
-      operationId: updaterecord
+      operationId: updateRecord
       responses:
         '200':
           description: OK
@@ -208,7 +208,7 @@ paths:
     parameters: []
     post:
       summary: Create record information
-      operationId: createrecord
+      operationId: createRecord
       responses:
         '200':
           description: OK
@@ -295,7 +295,7 @@ paths:
         - database
     delete:
       summary: Delete database information
-      operationId: deletedatabase
+      operationId: deleteDatabase
       responses:
         '200':
           description: OK
@@ -304,7 +304,7 @@ paths:
         - database
     patch:
       summary: Update database information
-      operationId: updatedatabase
+      operationId: updateDatabase
       responses:
         '200':
           description: OK
@@ -385,7 +385,7 @@ paths:
     parameters: []
     post:
       summary: Create database information
-      operationId: createdatabase
+      operationId: createDatabase
       responses:
         '200':
           description: OK
@@ -448,7 +448,7 @@ paths:
                               - front
                               - center
                               - timestamps
-      operationId: listfiles
+      operationId: listFiles
       description: List files
       parameters:
         - name: per_page
@@ -487,7 +487,7 @@ paths:
         - file
     post:
       summary: Create file information
-      operationId: createfile
+      operationId: createFile
       responses:
         '200':
           description: OK
@@ -579,7 +579,7 @@ paths:
                           - front
                           - center
                           - timestamps
-      operationId: getfile
+      operationId: getFile
       description: Get file information
       parameters:
         - schema:
@@ -596,7 +596,7 @@ paths:
           description: Record ID
     delete:
       summary: Delete file information
-      operationId: deletefile
+      operationId: deleteFile
       responses:
         '200':
           description: OK
@@ -618,7 +618,7 @@ paths:
           required: true
     patch:
       summary: Update file information
-      operationId: updatefile
+      operationId: updateFile
       responses:
         '200':
           description: OK


### PR DESCRIPTION
## What?
- Fix operation id of meta-store to camel case

## Why?
- To unify operation id format
