### PR TITLE
Change additionalProperties value

### DIFF
--- a/schemas/apis/api-meta-store/schema.v1.yaml
+++ b/schemas/apis/api-meta-store/schema.v1.yaml
@@ -800,7 +800,7 @@ components:
           minLength: 1
         contents:
           type: object
-      additionalProperties: true
+      additionalProperties: {}
       required:
         - record_id
     CreateRecordRequest:
@@ -816,7 +816,7 @@ components:
           type: string
         description:
           type: string
-      additionalProperties: true
+      additionalProperties: {}
     UpdateRecordRequest:
       description: ''
       type: object
@@ -1057,7 +1057,7 @@ components:
           type: string
         uuid:
           type: string
-      additionalProperties: true
+      additionalProperties: {}
       required:
         - path
         - uuid
@@ -1090,7 +1090,7 @@ components:
           type: number
         contents:
           type: object
-      additionalProperties: true
+      additionalProperties: {}
     CreateFileRequest:
       description: ''
       type: object
@@ -1115,7 +1115,7 @@ components:
           minLength: 1
         contents:
           type: object
-      additionalProperties: true
+      additionalProperties: {}
       required:
         - path
     DeleteDatabaseResponse:
@@ -1246,7 +1246,7 @@ components:
           type: array
           items:
             type: string
-      additionalProperties: true
+      additionalProperties: {}
       required:
         - columns
         - index_columns
@@ -1348,7 +1348,7 @@ components:
           type: array
           items:
             type: string
-      additionalProperties: true
+      additionalProperties: {}
       required:
         - columns
         - index_columns


### PR DESCRIPTION
## What?
- Change additionalProperties value

## Why?
- typescript-openapi-codegen が `additionalProperties: true` としただけでは型を変えてくれなかったので

## See also
- `additionalProperties: {}` が含まれるスキーマは `Record<string, any>` となっていた
- オブジェクト型であること以外に情報がないので，メタデータをJSON 文字列として扱う場合と比べて，型の情報量は変わらないものになった