### PR TITLE
Support for testing `api-meta-store`

### DIFF
--- a/schemas/apis/api-meta-store/schema.v1.yaml
+++ b/schemas/apis/api-meta-store/schema.v1.yaml
@@ -706,7 +706,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: ../api-file-provider/schema.v1.yaml#/components/schemas/ErrorModel
+                $ref: '#/components/schemas/ErrorModel'
         '404':
           description: Not Found
           content:


### PR DESCRIPTION
## What?
`api-meta-store` を OpenAPI 仕様書に基づいてテストするために仕様書側を整備

## Why?
仕様書を使ってテストしたいから

## Differences
- `ErrorModel` を追加
- 200以外のステータスコードを追加
- パラメータのパターンを定義

## TODO
- [x] `/databases` のテスト
- [x] `/databases/{database_id}/records` のテスト
- [x] `/databases/{database_id}/files` のテスト
- [x] `/databases/{database_id}/config` のテスト
