### PR TITLE
Support for generating record_id in api-meta-store

### DIFF
--- a/schemas/apis/api-meta-store/schema.v1.yaml
+++ b/schemas/apis/api-meta-store/schema.v1.yaml
@@ -1042,6 +1042,7 @@ components:
           description: Driving Database
           record_id: '016_00000000030000000240'
       title: CreateRecordRequest
+      additionalProperties: {}
       properties:
         record_id:
           type: string
@@ -1049,9 +1050,6 @@ components:
           minLength: 1
         description:
           type: string
-      additionalProperties: {}
-      required:
-        - record_id
     UpdateRecordRequest:
       description: ''
       type: object


### PR DESCRIPTION
## What?
`api-meta-store` の `createRecord` で `record_id` が指定されない場合に自動生成する仕様に変更

## Why?
`record_id` を指定しない場合も考えられるため

## See also [Optional]
https://github.com/dataware-tools/api-meta-store/issues/10