### PR TITLE
Set the minimum value of `per_page` in api-meta-store

### DIFF
--- a/schemas/apis/api-meta-store/schema.v1.yaml
+++ b/schemas/apis/api-meta-store/schema.v1.yaml
@@ -176,6 +176,7 @@ paths:
           in: query
           schema:
             type: integer
+            minimum: 1
         - name: page
           description: Page number
           in: query
@@ -422,6 +423,7 @@ paths:
           in: query
           schema:
             type: integer
+            minimum: 1
         - name: page
           description: Page number
           in: query
@@ -564,6 +566,7 @@ paths:
           in: query
           schema:
             type: integer
+            minimum: 1
         - name: page
           description: Page number
           in: query


### PR DESCRIPTION
## What?
api-meta-store の list* で `per_page` の最小値を設定

## Why?
実装に合わせるため