### PR TITLE
Add `search_key` to query params of api-meta-store

### DIFF
--- a/schemas/apis/api-meta-store/schema.v1.yaml
+++ b/schemas/apis/api-meta-store/schema.v1.yaml
@@ -192,6 +192,12 @@ paths:
           in: query
           schema:
             type: string
+        - schema:
+            type: array
+            example: ["name", "id"]
+          in: query
+          name: search_key
+          description: Which key to fuzzy search
       responses:
         '200':
           content:
@@ -439,6 +445,12 @@ paths:
           in: query
           schema:
             type: string
+        - schema:
+            type: array
+            example: ["name", "id"]
+          in: query
+          name: search_key
+          description: Which key to fuzzy search
       summary: List databases
       responses:
         '200':
@@ -587,6 +599,12 @@ paths:
           in: query
           name: record_id
           description: Record id
+        - schema:
+            type: array
+            example: ["name", "id"]
+          in: query
+          name: search_key
+          description: Which key to fuzzy search
       tags:
         - file
     post:


### PR DESCRIPTION
## What?
api-meta-store の `list*` 関数に `search_key` というクエリパラメータを追加

## Why?
どのキーであいまい検索を行うかをクライアント側から指定できるようにするため

## See also [Optional]
https://github.com/dataware-tools/api-meta-store/issues/20