### PR TITLE
Fix request body property name of file-provider

### DIFF
--- a/schemas/apis/api-file-provider/schema.v1.yaml
+++ b/schemas/apis/api-file-provider/schema.v1.yaml
@@ -123,6 +123,7 @@ paths:
                 properties:
                   save_file_path:
                     type: string
+                additionalProperties: {}
         '409':
           description: A file with the same path already exists.
           content:


### PR DESCRIPTION
## What?
- Fix request body property name of file-provider

## Why?
- file-provider でコンテンツではなくメタデータを受け取るようにしたから
