### PR TITLE
Add permitted-databases resource

### DIFF
--- a/.github/workflows/test_generate_openapi_client.yml
+++ b/.github/workflows/test_generate_openapi_client.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   generate-openapi-client:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 300
     strategy:
       matrix:

--- a/schemas/apis/api-permission-manager/schema.v1.yaml
+++ b/schemas/apis/api-permission-manager/schema.v1.yaml
@@ -514,8 +514,14 @@ components:
       properties:
         database_ids:
           type: array
+          description: Ids of permitted databases.
           items:
             type: string
+        selected_indices:
+          type: array
+          description: Indices of permitted databases in input.
+          items:
+            type: integer
   responses: {}
   parameters:
     per_page:

--- a/schemas/apis/api-permission-manager/schema.v1.yaml
+++ b/schemas/apis/api-permission-manager/schema.v1.yaml
@@ -255,6 +255,27 @@ paths:
       description: Get if the action is permitted on a database.
       tags:
         - permitted-action
+  /permitted-databases:
+    get:
+      summary: Your GET endpoint
+      tags:
+        - permitted-database
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPermittedDatabasesResponse'
+      operationId: getPermittedDatabases
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetPermittedDatabasesRequest'
+        description: ''
+      description: Get list of permitted databases filtered from the input.
 components:
   schemas:
     RoleModel:
@@ -473,6 +494,28 @@ components:
           $ref: '#/components/schemas/ActionModel'
       required:
         - actions
+    GetPermittedDatabasesRequest:
+      title: GetPermittedDatabasesRequest
+      type: object
+      properties:
+        database_ids:
+          type: array
+          description: Id of databases for checking permitted or not to read.
+          items:
+            type: string
+        user_id:
+          type: string
+          description: 'User id to check permission. If not specified, the id of the accessing user is used.'
+      required:
+        - database_ids
+    GetPermittedDatabasesResponse:
+      title: GetPermittedDatabasesResponse
+      type: object
+      properties:
+        database_ids:
+          type: array
+          items:
+            type: string
   responses: {}
   parameters:
     per_page:


### PR DESCRIPTION
## What?

api-permission-manager に追加した permitted-databases リソースの仕様書追加

## Why?

リソースを追加したため

## See also [Optional]

追加したリソース: https://github.com/dataware-tools/api-permission-manager/pull/33

## Screenshot or video [Optional]
