### PR TITLE
Add api-label-store

### DIFF
--- a/schemas/apis/api-label-store/schema.v1.yaml
+++ b/schemas/apis/api-label-store/schema.v1.yaml
@@ -170,6 +170,7 @@ paths:
                     type: integer
                   total:
                     type: integer
+              examples: {}
         '400':
           $ref: '#/components/responses/ErrorResponse'
       operationId: get-tasks
@@ -187,6 +188,11 @@ paths:
           in: query
           name: reviewer_id
           description: ID of a reviewer for filtering.
+        - schema:
+            type: string
+          in: query
+          name: application_id
+          description: ID of an application for filtering.
     post:
       summary: ''
       operationId: post-tasks
@@ -208,6 +214,40 @@ paths:
             schema:
               $ref: '#/components/schemas/ArrayableTask'
         description: Task to create can be both single and multiple.
+  /tasks/publish:
+    post:
+      summary: Publish tasks
+      operationId: publish-tasks
+      responses:
+        '200':
+          description: OK
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
+      description: Publish tasks.
+      tags:
+        - task
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                task_ids:
+                  oneOf:
+                    - properties: {}
+                      type: integer
+                    - type: array
+                      items:
+                        type: integer
+                  description: ID of tasks to publish. Either an integer or array of integers.
+                filename:
+                  type: string
+              required:
+                - task_ids
 components:
   schemas:
     LabelModel:
@@ -261,6 +301,14 @@ components:
           type: string
         reviewer_id:
           type: string
+        deadline:
+          type: string
+          format: date
+          example: '2017-07-21'
+        annotation_completed:
+          type: boolean
+        review_completed:
+          type: boolean
         created_at:
           $ref: '#/components/schemas/AutoDateTimeField'
         updated_at:

--- a/schemas/apis/api-label-store/schema.v1.yaml
+++ b/schemas/apis/api-label-store/schema.v1.yaml
@@ -24,7 +24,6 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - {}
                   - type: object
                     properties:
                       data:
@@ -344,6 +343,7 @@ components:
         uuid:
           type: string
           format: uuid
+          readOnly: true
         task_id:
           type: integer
         range_start:
@@ -363,8 +363,6 @@ components:
           $ref: '#/components/schemas/AutoDateTimeField'
       required:
         - uuid
-        - task_id
-      readOnly: true
     TaskModel:
       title: Task
       type: object
@@ -401,9 +399,6 @@ components:
           $ref: '#/components/schemas/AutoDateTimeField'
       required:
         - id
-        - database_id
-        - record_id
-        - application_id
     ArrayableTask:
       oneOf:
         - $ref: '#/components/schemas/TaskModel'

--- a/schemas/apis/api-label-store/schema.v1.yaml
+++ b/schemas/apis/api-label-store/schema.v1.yaml
@@ -151,6 +151,22 @@ paths:
                   range_end: '2017-07-21T17:32:28Z'
                   label_data: {}
         description: ''
+    delete:
+      summary: Delete label
+      operationId: delete-label
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+      description: Delete a label.
   /tasks:
     get:
       summary: List tasks
@@ -233,6 +249,11 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
         '400':
           $ref: '#/components/responses/ErrorResponse'
         '403':
@@ -305,6 +326,22 @@ paths:
             schema:
               $ref: '#/components/schemas/TaskModel'
       description: Update a task.
+    delete:
+      summary: Delete task
+      operationId: delete-task
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+      description: Delete a task.
 components:
   schemas:
     LabelModel:

--- a/schemas/apis/api-label-store/schema.v1.yaml
+++ b/schemas/apis/api-label-store/schema.v1.yaml
@@ -23,22 +23,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/LabelModel'
-                  number_of_pages:
-                    type: integer
-                  page:
-                    type: integer
-                  per_page:
-                    type: integer
-                  length:
-                    type: integer
-                  total:
-                    type: integer
+                allOf:
+                  - {}
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/LabelModel'
+                  - $ref: '#/components/schemas/BasicPaginationModel'
         '400':
           $ref: '#/components/responses/ErrorResponse'
         '403':
@@ -180,22 +173,14 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/TaskModel'
-                  number_of_pages:
-                    type: integer
-                  page:
-                    type: integer
-                  per_page:
-                    type: integer
-                  length:
-                    type: integer
-                  total:
-                    type: integer
+                allOf:
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/TaskModel'
+                  - $ref: '#/components/schemas/BasicPaginationModel'
               examples: {}
         '400':
           $ref: '#/components/responses/ErrorResponse'
@@ -433,6 +418,20 @@ components:
       example: '2017-07-21T17:32:28Z'
       format: date-time
       readOnly: true
+    BasicPaginationModel:
+      title: BasicPaginationModel
+      type: object
+      properties:
+        number_of_pages:
+          type: integer
+        page:
+          type: integer
+        per_page:
+          type: integer
+        length:
+          type: integer
+        total:
+          type: integer
   responses:
     ErrorResponse:
       description: Error response.

--- a/schemas/apis/api-label-store/schema.v1.yaml
+++ b/schemas/apis/api-label-store/schema.v1.yaml
@@ -388,8 +388,10 @@ components:
           type: string
         annotator_id:
           type: string
-        reviewer_id:
-          type: string
+        reviewer_ids:
+          type: array
+          items:
+            type: string
         deadline:
           type: string
           format: date
@@ -397,7 +399,10 @@ components:
         annotation_completed:
           type: boolean
         review_completed:
-          type: boolean
+          type: array
+          description: Array of user_ids who completed reviewing.
+          items:
+            type: string
         created_at:
           $ref: '#/components/schemas/AutoDateTimeField'
         updated_at:

--- a/schemas/apis/api-label-store/schema.v1.yaml
+++ b/schemas/apis/api-label-store/schema.v1.yaml
@@ -1,0 +1,148 @@
+openapi: 3.0.2
+info:
+  title: label store
+  version: '1.0'
+  description: Label related APIs.
+  contact:
+    name: Human Dataware Lab. Co. Ltd.
+    url: 'http://www.hdwlab.co.jp/'
+    email: contact@hdwlab.co.jp
+  license:
+    name: Apache-2.0
+servers:
+  - url: 'http://localhost:8080'
+paths:
+  /labels:
+    get:
+      summary: List labels
+      tags:
+        - label
+      responses:
+        '200':
+          $ref: '#/components/responses/ListLabelsResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-labels
+      description: List labels.
+      parameters:
+        - $ref: '#/components/parameters/per_page'
+        - $ref: '#/components/parameters/page'
+        - schema:
+            type: integer
+          in: query
+          name: task_id
+          description: ID of a task for filtering.
+        - schema:
+            type: string
+            format: date-time
+            example: '2017-07-21T17:32:28Z'
+          in: query
+          name: range_start
+          description: Start time of the range for filtering.
+        - schema:
+            type: string
+            format: date-time
+            example: '2017-07-21T17:32:28Z'
+          in: query
+          name: range_end
+          description: End time of the range for filtering.
+    post:
+      summary: Create new label
+      operationId: post-label
+      tags:
+        - label
+      description: Create a new label.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LabelModel'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+components:
+  schemas:
+    LabelModel:
+      type: object
+      title: LabelModel
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        task_id:
+          type: integer
+        range_start:
+          type: string
+          format: date-time
+          example: '2017-07-21T17:32:28Z'
+        range_end:
+          type: string
+          format: date-time
+          example: '2017-07-21T17:32:28Z'
+        label_data:
+          type: object
+          description: Label object which is the JSONField.
+        created_at:
+          type: string
+          format: date-time
+          example: '2017-07-21T17:32:28Z'
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          example: '2017-07-21T17:32:28Z'
+          readOnly: true
+      required:
+        - uuid
+        - task_id
+      readOnly: true
+      description: ''
+  responses:
+    ListLabelsResponse:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LabelModel'
+              number_of_pages:
+                type: integer
+              page:
+                type: integer
+              per_page:
+                type: integer
+              length:
+                type: integer
+              total:
+                type: integer
+    ErrorResponse:
+      description: Error response.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              detail:
+                type: string
+  parameters:
+    per_page:
+      name: per_page
+      in: query
+      required: false
+      schema:
+        type: integer
+      description: Number of items to return per page.
+    page:
+      name: page
+      in: query
+      required: false
+      schema:
+        type: number
+      description: Page number.
+tags:
+  - name: label

--- a/schemas/apis/api-label-store/schema.v1.yaml
+++ b/schemas/apis/api-label-store/schema.v1.yaml
@@ -191,7 +191,7 @@ paths:
         '403':
           $ref: '#/components/responses/ErrorResponse'
       operationId: get-tasks
-      description: List tasks.
+      description: List tasks that are permitted to read for the requested user.
       parameters:
         - $ref: '#/components/parameters/per_page'
         - $ref: '#/components/parameters/page'

--- a/schemas/apis/api-label-store/schema.v1.yaml
+++ b/schemas/apis/api-label-store/schema.v1.yaml
@@ -23,14 +23,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - type: object
-                    properties:
-                      data:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/LabelModel'
-                  - $ref: '#/components/schemas/BasicPaginationModel'
+                $ref: '#/components/schemas/ListLabelsResponse'
         '400':
           $ref: '#/components/responses/ErrorResponse'
         '403':
@@ -177,14 +170,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - type: object
-                    properties:
-                      data:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/TaskModel'
-                  - $ref: '#/components/schemas/BasicPaginationModel'
+                $ref: '#/components/schemas/ListTasksResponse'
               examples: {}
         '400':
           $ref: '#/components/responses/ErrorResponse'
@@ -452,6 +438,26 @@ components:
           type: integer
         total:
           type: integer
+    ListLabelsResponse:
+      title: ListLabelsResponseBody
+      allOf:
+        - type: object
+          properties:
+            data:
+              type: array
+              items:
+                $ref: '#/components/schemas/LabelModel'
+        - $ref: '#/components/schemas/BasicPaginationModel'
+    ListTasksResponse:
+      title: ListTasksResponseBody
+      allOf:
+        - type: object
+          properties:
+            data:
+              type: array
+              items:
+                $ref: '#/components/schemas/TaskModel'
+        - $ref: '#/components/schemas/BasicPaginationModel'
   responses:
     ErrorResponse:
       description: Error response.

--- a/schemas/apis/api-label-store/schema.v1.yaml
+++ b/schemas/apis/api-label-store/schema.v1.yaml
@@ -100,7 +100,7 @@ paths:
         description: ''
   '/labels/{label_id}':
     get:
-      summary: Your GET endpoint
+      summary: Get label
       tags:
         - label
       responses:
@@ -119,7 +119,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/label_id'
     patch:
-      summary: ''
+      summary: Update label
       operationId: patch-label
       responses:
         '200':
@@ -167,6 +167,8 @@ paths:
         '404':
           $ref: '#/components/responses/ErrorResponse'
       description: Delete a label.
+      tags:
+        - label
   /tasks:
     get:
       summary: List tasks
@@ -220,7 +222,7 @@ paths:
           name: application_id
           description: ID of an application for filtering.
     post:
-      summary: ''
+      summary: Create task
       operationId: post-tasks
       responses:
         '200':
@@ -292,7 +294,8 @@ paths:
         required: true
     get:
       summary: Your GET endpoint
-      tags: []
+      tags:
+        - task
       responses:
         '200':
           description: OK
@@ -307,7 +310,7 @@ paths:
       operationId: get-task
       description: Get a task.
     patch:
-      summary: ''
+      summary: Update task
       operationId: patch-task
       responses:
         '200':
@@ -326,6 +329,8 @@ paths:
             schema:
               $ref: '#/components/schemas/TaskModel'
       description: Update a task.
+      tags:
+        - task
     delete:
       summary: Delete task
       operationId: delete-task
@@ -342,6 +347,8 @@ paths:
         '404':
           $ref: '#/components/responses/ErrorResponse'
       description: Delete a task.
+      tags:
+        - task
 components:
   schemas:
     LabelModel:

--- a/schemas/apis/api-label-store/schema.v1.yaml
+++ b/schemas/apis/api-label-store/schema.v1.yaml
@@ -85,7 +85,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/LabelModel'
+              $ref: '#/components/schemas/LabelModelForCreate'
             examples:
               example-1:
                 value:
@@ -368,6 +368,12 @@ components:
           $ref: '#/components/schemas/AutoDateTimeField'
       required:
         - uuid
+    LabelModelForCreate:
+      allOf:
+        - $ref: '#/components/schemas/LabelModel'
+      required:
+        - task_id
+        - label_data
     TaskModel:
       title: Task
       type: object
@@ -409,13 +415,22 @@ components:
           $ref: '#/components/schemas/AutoDateTimeField'
       required:
         - id
+    TaskModelForCreate:
+      title: TaskModelForCreate
+      allOf:
+        - $ref: '#/components/schemas/TaskModel'
+      required:
+        - database_id
+        - record_id
+        - application_id
+        - name
+      description: Model for creating a task object.
     ArrayableTask:
       oneOf:
-        - $ref: '#/components/schemas/TaskModel'
+        - $ref: '#/components/schemas/TaskModelForCreate'
         - type: array
           items:
-            $ref: '#/components/schemas/TaskModel'
-      title: ''
+            $ref: '#/components/schemas/TaskModelForCreate'
       description: ''
     AutoDateTimeField:
       type: string

--- a/schemas/apis/api-label-store/schema.v1.yaml
+++ b/schemas/apis/api-label-store/schema.v1.yaml
@@ -19,7 +19,26 @@ paths:
         - label
       responses:
         '200':
-          $ref: '#/components/responses/ListLabelsResponse'
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LabelModel'
+                  number_of_pages:
+                    type: integer
+                  page:
+                    type: integer
+                  per_page:
+                    type: integer
+                  length:
+                    type: integer
+                  total:
+                    type: integer
         '400':
           $ref: '#/components/responses/ErrorResponse'
       operationId: get-labels
@@ -124,12 +143,77 @@ paths:
                   range_end: '2017-07-21T17:32:28Z'
                   label_data: {}
         description: ''
+  /tasks:
+    get:
+      summary: List tasks
+      tags:
+        - task
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/TaskModel'
+                  number_of_pages:
+                    type: integer
+                  page:
+                    type: integer
+                  per_page:
+                    type: integer
+                  length:
+                    type: integer
+                  total:
+                    type: integer
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-tasks
+      description: List tasks.
+      parameters:
+        - $ref: '#/components/parameters/per_page'
+        - $ref: '#/components/parameters/page'
+        - schema:
+            type: string
+          in: query
+          name: annotator_id
+          description: ID of an annotator for filtering.
+        - schema:
+            type: string
+          in: query
+          name: reviewer_id
+          description: ID of a reviewer for filtering.
+    post:
+      summary: ''
+      operationId: post-tasks
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArrayableTask'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+      description: Create new tasks.
+      tags:
+        - task
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ArrayableTask'
+        description: Task to create can be both single and multiple.
 components:
   schemas:
     LabelModel:
       type: object
       title: LabelModel
-      description: ''
+      description: Model for a label object.
       properties:
         uuid:
           type: string
@@ -148,41 +232,59 @@ components:
           description: Label object which is the JSONField.
           type: object
         created_at:
-          type: string
-          format: date-time
-          example: '2017-07-21T17:32:28Z'
-          readOnly: true
+          $ref: '#/components/schemas/AutoDateTimeField'
         updated_at:
-          type: string
-          format: date-time
-          example: '2017-07-21T17:32:28Z'
-          readOnly: true
+          $ref: '#/components/schemas/AutoDateTimeField'
       required:
         - uuid
         - task_id
       readOnly: true
+    TaskModel:
+      title: Task
+      type: object
+      description: Model for a task object.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        database_id:
+          type: string
+        record_id:
+          type: string
+        application_id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        annotator_id:
+          type: string
+        reviewer_id:
+          type: string
+        created_at:
+          $ref: '#/components/schemas/AutoDateTimeField'
+        updated_at:
+          $ref: '#/components/schemas/AutoDateTimeField'
+      required:
+        - id
+        - database_id
+        - record_id
+        - application_id
+    ArrayableTask:
+      oneOf:
+        - $ref: '#/components/schemas/TaskModel'
+        - type: array
+          items:
+            $ref: '#/components/schemas/TaskModel'
+      title: ''
+      description: ''
+    AutoDateTimeField:
+      type: string
+      title: created_at
+      example: '2017-07-21T17:32:28Z'
+      format: date-time
+      readOnly: true
   responses:
-    ListLabelsResponse:
-      description: Example response
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              data:
-                type: array
-                items:
-                  $ref: '#/components/schemas/LabelModel'
-              number_of_pages:
-                type: integer
-              page:
-                type: integer
-              per_page:
-                type: integer
-              length:
-                type: integer
-              total:
-                type: integer
     ErrorResponse:
       description: Error response.
       content:
@@ -192,6 +294,7 @@ components:
             properties:
               detail:
                 type: string
+          examples: {}
   parameters:
     per_page:
       name: per_page
@@ -217,3 +320,4 @@ components:
       description: ID of a label.
 tags:
   - name: label
+  - name: task

--- a/schemas/apis/api-label-store/schema.v1.yaml
+++ b/schemas/apis/api-label-store/schema.v1.yaml
@@ -428,6 +428,12 @@ components:
           type: integer
         total:
           type: integer
+    ErrorModel:
+      title: ErrorModel
+      type: object
+      properties:
+        detail:
+          type: string
     ListLabelsResponse:
       title: ListLabelsResponseBody
       allOf:
@@ -454,10 +460,7 @@ components:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              detail:
-                type: string
+            $ref: '#/components/schemas/ErrorModel'
           examples: {}
     DeleteSuccessResponse:
       description: Response for succeeded DELETE method.

--- a/schemas/apis/api-label-store/schema.v1.yaml
+++ b/schemas/apis/api-label-store/schema.v1.yaml
@@ -429,7 +429,7 @@ components:
       description: ''
     AutoDateTimeField:
       type: string
-      title: created_at
+      title: ''
       example: '2017-07-21T17:32:28Z'
       format: date-time
       readOnly: true

--- a/schemas/apis/api-label-store/schema.v1.yaml
+++ b/schemas/apis/api-label-store/schema.v1.yaml
@@ -61,11 +61,75 @@ paths:
                 $ref: '#/components/schemas/LabelModel'
         '400':
           $ref: '#/components/responses/ErrorResponse'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LabelModel'
+            examples:
+              example-1:
+                value:
+                  uuid: 095be615-a8ad-4c33-8e9c-c7612fbf6c9f
+                  task_id: 0
+                  range_start: '2017-07-21T17:32:28Z'
+                  range_end: '2017-07-21T17:32:28Z'
+                  label_data: {}
+        description: ''
+  '/labels/{label_id}':
+    get:
+      summary: Your GET endpoint
+      tags:
+        - label
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LabelModel'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-label
+      description: Get a label.
+    parameters:
+      - $ref: '#/components/parameters/label_id'
+    patch:
+      summary: ''
+      operationId: patch-label
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LabelModel'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+      tags:
+        - label
+      description: Update a label.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LabelModel'
+            examples:
+              example-1:
+                value:
+                  uuid: 095be615-a8ad-4c33-8e9c-c7612fbf6c9f
+                  task_id: 0
+                  range_start: '2017-07-21T17:32:28Z'
+                  range_end: '2017-07-21T17:32:28Z'
+                  label_data: {}
+        description: ''
 components:
   schemas:
     LabelModel:
       type: object
       title: LabelModel
+      description: ''
       properties:
         uuid:
           type: string
@@ -81,8 +145,8 @@ components:
           format: date-time
           example: '2017-07-21T17:32:28Z'
         label_data:
-          type: object
           description: Label object which is the JSONField.
+          type: object
         created_at:
           type: string
           format: date-time
@@ -97,7 +161,6 @@ components:
         - uuid
         - task_id
       readOnly: true
-      description: ''
   responses:
     ListLabelsResponse:
       description: Example response
@@ -144,5 +207,13 @@ components:
       schema:
         type: number
       description: Page number.
+    label_id:
+      name: label_id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: ID of a label.
 tags:
   - name: label

--- a/schemas/apis/api-label-store/schema.v1.yaml
+++ b/schemas/apis/api-label-store/schema.v1.yaml
@@ -59,6 +59,11 @@ paths:
           in: query
           name: range_end
           description: End time of the range for filtering.
+        - schema:
+            type: string
+          in: query
+          description: ID of a record for filtering.
+          name: record_id
     post:
       summary: Create new label
       operationId: post-label

--- a/schemas/apis/api-label-store/schema.v1.yaml
+++ b/schemas/apis/api-label-store/schema.v1.yaml
@@ -41,6 +41,8 @@ paths:
                     type: integer
         '400':
           $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
       operationId: get-labels
       description: List labels.
       parameters:
@@ -80,6 +82,8 @@ paths:
                 $ref: '#/components/schemas/LabelModel'
         '400':
           $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
       requestBody:
         content:
           application/json:
@@ -106,6 +110,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LabelModel'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
         '404':
           $ref: '#/components/responses/ErrorResponse'
       operationId: get-label
@@ -123,6 +129,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/LabelModel'
         '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
           $ref: '#/components/responses/ErrorResponse'
         '404':
           $ref: '#/components/responses/ErrorResponse'
@@ -173,6 +181,8 @@ paths:
               examples: {}
         '400':
           $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
       operationId: get-tasks
       description: List tasks.
       parameters:
@@ -205,6 +215,8 @@ paths:
                 $ref: '#/components/schemas/ArrayableTask'
         '400':
           $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
       description: Create new tasks.
       tags:
         - task
@@ -222,6 +234,8 @@ paths:
         '200':
           description: OK
         '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
           $ref: '#/components/responses/ErrorResponse'
         '404':
           $ref: '#/components/responses/ErrorResponse'
@@ -248,6 +262,49 @@ paths:
                   type: string
               required:
                 - task_ids
+  '/tasks/{task_id}':
+    parameters:
+      - schema:
+          type: string
+        name: task_id
+        in: path
+        required: true
+    get:
+      summary: Your GET endpoint
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskModel'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+      operationId: get-task
+      description: Get a task.
+    patch:
+      summary: ''
+      operationId: patch-task
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskModel'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaskModel'
+      description: Update a task.
 components:
   schemas:
     LabelModel:

--- a/schemas/apis/api-label-store/schema.v1.yaml
+++ b/schemas/apis/api-label-store/schema.v1.yaml
@@ -146,12 +146,7 @@ paths:
       operationId: delete-label
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties: {}
+          $ref: '#/components/responses/DeleteSuccessResponse'
         '403':
           $ref: '#/components/responses/ErrorResponse'
         '404':
@@ -311,12 +306,7 @@ paths:
       operationId: delete-task
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties: {}
+          $ref: '#/components/responses/DeleteSuccessResponse'
         '403':
           $ref: '#/components/responses/ErrorResponse'
         '404':
@@ -469,6 +459,8 @@ components:
               detail:
                 type: string
           examples: {}
+    DeleteSuccessResponse:
+      description: Response for succeeded DELETE method.
   parameters:
     per_page:
       name: per_page


### PR DESCRIPTION
## What?

api-label-store の仕様書追加

## Why?

新しくAPIを作成したい

## See also [Optional]

https://github.com/dataware-tools/dataware-tools/issues/74

## TODOs

- [x] /labels
- [x] /labels/{label_id}
- [x] /tasks
- [x] /tasks/publish
- [x] /tasks/{task_id}

### Fixes

- [x] POST/PATCH 時の required を設定
- [x] GET /tasks ではリクエストヘッダのトークンで権限があるものを全て返すことを明記
- [x] タスクに紐づける reviewer を複数指定可能に
- [x] GET /labels で record_id での絞り込みに対応
- [x] リクエスト・レスポンスに名前を付ける