### PR TITLE
Add database_id param to delete file

### DIFF
--- a/schemas/apis/api-file-provider/schema.v1.yaml
+++ b/schemas/apis/api-file-provider/schema.v1.yaml
@@ -216,7 +216,9 @@ components:
       description: Post request for creating a JWT to download a file
       x-examples:
         example-1:
-          path: /opt/app/pyproject.toml
+          value:
+            path: /opt/app/pyproject.toml
+            database_id: sample_database_id
       properties:
         path:
           type: string

--- a/schemas/apis/api-file-provider/schema.v1.yaml
+++ b/schemas/apis/api-file-provider/schema.v1.yaml
@@ -214,6 +214,9 @@ components:
       title: DownloadsPostModel
       type: object
       description: Post request for creating a JWT to download a file
+      x-examples:
+        example-1:
+          path: /opt/app/pyproject.toml
       properties:
         path:
           type: string
@@ -229,9 +232,7 @@ components:
           description: 'If specified, Content-type in the response headers will contain this value'
       required:
         - path
-      x-examples:
-        example-1:
-          path: /opt/app/pyproject.toml
+        - database_id
     DownloadsPostedModel:
       title: DownloadsPostedModel
       type: object

--- a/schemas/apis/api-file-provider/schema.v1.yaml
+++ b/schemas/apis/api-file-provider/schema.v1.yaml
@@ -202,6 +202,12 @@ paths:
           name: path
           description: File path
           required: true
+        - schema:
+            type: string
+          in: query
+          name: database_id
+          description: Database ID
+          required: true
 components:
   schemas:
     DownloadsPostModel:


### PR DESCRIPTION
## What?

api-file-provider の /delete に database_id パラメータを追加
POST /download の database_id パラメータに required を付与

## Why?

API実装の変更に追従

## See also [Optional]

Issue: https://github.com/dataware-tools/dataware-tools/issues/72
API実装変更: https://github.com/dataware-tools/api-file-provider/pull/26

## Screenshot or video [Optional]
