### PR TITLE
Add `database_id` and `record_id` to JobPostModel

### DIFF
--- a/schemas/apis/api-job-store/schema.v1.yaml
+++ b/schemas/apis/api-job-store/schema.v1.yaml
@@ -2460,6 +2460,13 @@ components:
     JobPostModel:
       description: ''
       type: object
+      x-examples:
+        example-1:
+          job_template_id: 15
+          path_to_rosbag: /Users/d_hayashi/data/sample.bag
+          data_dirs:
+            - /Users/d_hayashi/data
+          env_vars: {}
       properties:
         job_template_id:
           type: number
@@ -2476,15 +2483,12 @@ components:
           type: string
         memory_limits:
           type: string
+        database_id:
+          type: string
+        record_id:
+          type: string
       required:
         - job_template_id
-      x-examples:
-        example-1:
-          job_template_id: 15
-          path_to_rosbag: /Users/d_hayashi/data/sample.bag
-          data_dirs:
-            - /Users/d_hayashi/data
-          env_vars: {}
     JobPostedModel:
       description: ''
       type: object


### PR DESCRIPTION
## What?
Add the following properties to `JobPostModel`
- `database_id`
- `record_id`

## Why?
To support job-type `ROSProviderWithPyDTKJob`

## See also [Optional]
https://github.com/dataware-tools/api-job-store/pull/26