### PR TITLE
Fix CommentedPointAnnotation type

### DIFF
--- a/schemas/apis/api-annotation-store/schema.v1.yaml
+++ b/schemas/apis/api-annotation-store/schema.v1.yaml
@@ -118,30 +118,21 @@ components:
           required:
             - text
             - frame_id
-            - pose
+            - point
           properties:
             text:
               type: string
             frame_id:
               type: string
-            pose:
+            point:
               type: object
-              required:
-                - position
               properties:
-                position:
-                  type: object
-                  required:
-                    - x
-                    - y
-                    - z
-                  properties:
-                    x:
-                      type: number
-                    y:
-                      type: number
-                    z:
-                      type: number
+                x:
+                  type: number
+                'y':
+                  type: number
+                z:
+                  type: number
       required:
         - commented_pose
     AnnotationBody:

--- a/schemas/apis/api-annotation-store/schema.v1.yaml
+++ b/schemas/apis/api-annotation-store/schema.v1.yaml
@@ -113,7 +113,7 @@ components:
       title: CommentedPointAnnotationBody
       additionalProperties: false
       properties:
-        commented_pose:
+        commented_point:
           type: object
           required:
             - text
@@ -126,15 +126,19 @@ components:
               type: string
             point:
               type: object
+              required:
+                - x
+                - y
+                - z
               properties:
                 x:
                   type: number
-                'y':
+                y:
                   type: number
                 z:
                   type: number
       required:
-        - commented_pose
+        - commented_point
     AnnotationBody:
       oneOf:
         - $ref: '#/components/schemas/CommentedPointAnnotationBody'
@@ -268,5 +272,3 @@ components:
                   - record_id
                   - timestamp_from
                   - timestamp_to
-tags:
-  - name: annotation


### PR DESCRIPTION
## What?
Fix CommentedPointAnnotation type

## Why?
座標の情報しか持たないのに、commented_pose.pose.point だと冗長だから
